### PR TITLE
Fix #25 auto load issue

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@ use PhpDeal\ContractApplication;
 
 if (defined("AUTOLOAD_PATH")) {
     if (is_file(__DIR__ . '/../' .AUTOLOAD_PATH)) {
-        $loader = include_once __DIR__ . '/../' . AUTOLOAD_PATH;
+        $loader = include __DIR__ . '/../' . AUTOLOAD_PATH;
         $loader->addPsr4('PhpDeal\\', __DIR__);
     } else {
         throw new InvalidArgumentException("Cannot load custom autoload file located at ".AUTOLOAD_PATH);


### PR DESCRIPTION
The composer auto loader was being included via `include_once`. This was
preventing the bootstrap file from executing when the composer autoloader
had already been `include`d by PHPUnit. The composer auto loader appears
to be designed to be included many times, as the `getLoader()` function
caches it's results.

This patch fixes the issue.