### PR TITLE
Version 1.x

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.coverage.sh export-ignore
+.travis.yml export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 .travis.yml export-ignore
 phpcs.xml.dist export-ignore
 phpunit.xml.dist export-ignore
+phpstan.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
-/vendor/
+# Composer
+vendor/
 composer.lock
+
+# Cache
 /tests/cache/
 /demo/cache/
+
+# Code quality
+/phpunit.xml
+/phpcs.xml
+/phpstan.neon

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 /tests/cache/
+/demo/cache/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,7 @@ tools:
     php_code_sniffer:
         enabled: true
         config:
-            standard: PSR2
+            standard: PSR12
         filter:
             paths: ["src/*"]
     php_cpd:

--- a/.travis.coverage.sh
+++ b/.travis.coverage.sh
@@ -1,5 +1,5 @@
 set -x
-if [ "$TRAVIS_PHP_VERSION" = '7.0' ] ; then
+if [ "$TRAVIS_PHP_VERSION" = '7.2' ] ; then
     wget https://scrutinizer-ci.com/ocular.phar
     php ocular.phar code-coverage:upload --format=php-clover ./clover.xml
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer install
 
 script:
   - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=clover.xml --colors
+  - vendor/bin/phpcs src/ tests/
 
 after_script:
   - sh .travis.coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
 script:
   - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=clover.xml --colors
   - vendor/bin/phpcs src/ tests/
+  - vendor/bin/phpstan analyze
 
 after_script:
   - sh .travis.coverage.sh

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ To solve this issue try adding your `vendor` folder into the `excludePaths` conf
 ContractApplication::getInstance()->init(array(
     'debug'    => true,
     'appDir'   => __DIR__,,
-    'exludePaths' => [
+    'excludePaths' => [
         __DIR__ . '/vendor'
     ],
     'cacheDir' => __DIR__.'/cache/',

--- a/README.md
+++ b/README.md
@@ -148,16 +148,16 @@ There a some differences in inheritance of the contracts:
   - if provided `Ensure` will automatically inherit all contracts from parent class or interface
 2. Verify
   - if provided `Verify` will _not_ inherit contracts from parent class or interface
-  - to inherit contracts you will ne to provide `@inheritdoc` or the `Inherit` contract
+  - to inherit contracts you will need to provide `@inheritdoc` or the `Inherit` contract
 3. Invariant
   - if provided `Invariant` will inherit all contracts from parent class or interface
 4. Inherit
-  - if provided `Inherit` will inherit all contracts from the given leven (class, method) without the
+  - if provided `Inherit` will inherit all contracts from the given level (class, method) without the
   need to provide a contract on your current class or method
   
 __Notes__: 
 - The parsing of a contract only happens __IF__ you provide any given annotation from this package.
-Without it your contracts won't work!
+Without it, your contracts won't work!
 - The annotation __must not__ have curly braces (`{}`) otherwise the annotation reader can't find them.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -135,17 +135,30 @@ class Account
 ```
 Invariants contain assert expressions, and so when they fail, they throw a ContractViolation exception.
 
-NOTE! The code in the invariant may not call any public non-static members of the class, either directly or
+__NOTE__: The code in the invariant may not call any public non-static members of the class, either directly or
 indirectly. Doing so will result in a stack overflow, as the invariant will wind up being called in an
 infinitely recursive manner.
 
 Contract propagation
 ----------
 
-All contracts are propagated from parent classes and interfaces.
+There a some differences in inheritance of the contracts:
 
-For preconditions (Verify contracts) subclasses do not inherit contracts of parents' methods if they don't have the @inheritdoc annotation. Example:
-
+1. Ensure
+  - if provided `Ensure` will automatically inherit all contracts from parent class or interface
+2. Verify
+  - if provided `Verify` will _not_ inherit contracts from parent class or interface
+  - to inherit contracts you will ne to provide `@inheritdoc` or the `Inherit` contract
+3. Invariant
+  - if provided `Invariant` will inherit all contracts from parent class or interface
+4. Inherit
+  - if provided `Inherit` will inherit all contracts from the given leven (class, method) without the
+  need to provide a contract on your current class or method
+  
+__Notes__: 
+- The parsing of a contract only happens __IF__ you provide any given annotation from this package.
+Without it your contracts won't work!
+- The annotation __must not__ have curly braces (`{}`) otherwise the annotation reader can't find them.
 
 ```php
 
@@ -175,7 +188,7 @@ class FooParent
     
 ```
 
-Foo::bar accepts '2' literal as a parameter and does not accept '1'.
+`Foo::bar` accepts `2` literal as a parameter and does not accept `1`.
 
 With @inheritdoc:
 
@@ -208,12 +221,10 @@ class FooParent
     
 ```
 
-Foo::bar does not accept '1' and '2' literals as a parameter.
+`Foo::bar` does not accept `1` and `2` literals as a parameter.
 
 
-
-
-For postconditions (Ensure and Invariants contracts) subclasses inherit contracts and they don't need @inheritdoc. Example:
+For postconditions (Ensure and Invariants contracts) subclasses inherit contracts and they don't need `@inheritdoc`. Example:
 
 ```php
     
@@ -246,7 +257,37 @@ class FooParent
     
 ```
 
-Foo::setBar does not accept '1' and '2' literals as a parameter.
+`Foo::setBar` does not accept `1` and `2` literals as a parameter.
+
+If you don't want to provide a contract on your curent method/class you can use the `Inherit` annotation:
+
+```php
+class Foo extends FooParent
+{
+    /**
+     * @param int $amount
+     * @Contract\Inherit
+     */
+    public function bar($amount)
+    {
+        ...
+    }
+}
+    
+class FooParent
+{
+    /**
+     * @param int $amount
+     * @Contract\Verify("$amount != 2")
+     */
+    public function bar($amount)
+    {
+        ...
+    }
+}
+```
+
+`Foo:bar()` does accept eveything, except: `2`
 
 Integration with assertion library
 ----------

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ break a caller, C++ FAQs uses the memorable phrase "require no more, promise no 
 does not require more from the caller than before, and if it does not promise to deliver less than before,
 then the new specification is compatible with the old, and will not break the caller.
 
-[![Build Status](https://api.travis-ci.org/php-deal/framework.png?branch=master)](https://travis-ci.org/php-deal/framework)
+[![Build Status](https://api.travis-ci.org/php-deal/framework.png?branch=1.x)](https://travis-ci.org/php-deal/framework)
 [![GitHub release](https://img.shields.io/github/release/php-deal/framework.svg)](https://github.com/php-deal/framework/releases/latest)
-[![Code Coverage](https://scrutinizer-ci.com/g/php-deal/framework/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/php-deal/framework/?branch=master)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/php-deal/framework/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/php-deal/framework/?branch=master)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)](https://php.net/)
+[![Code Coverage](https://scrutinizer-ci.com/g/php-deal/framework/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/php-deal/framework/?branch=1.x)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/php-deal/framework/badges/quality-score.png?b=1.x)](https://scrutinizer-ci.com/g/php-deal/framework/?branch=1.x)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D7.2-blue.svg)](https://php.net/)
 [![License](https://img.shields.io/packagist/l/php-deal/framework.svg)](https://packagist.org/packages/php-deal/framework)
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "php-deal/framework",
     "description": "Design by Contract framework for PHP",
     "require": {
-        "php": ">=5.6.0",
-        "goaop/framework": "~2.0",
-        "beberlei/assert": "^2.4"
+        "php": "~7.0",
+        "goaop/framework": "~2.0"
     },
     "require-dev": {
         "symfony/console": "~2.7|~3.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "beberlei/assert": "~3.0"
     },
     "license": "MIT",
     "authors": [
@@ -27,5 +27,13 @@
     "autoload-dev": {
         "psr-0": {"Demo\\": "demo/"},
         "psr-4": {"PhpDeal\\": "tests/"}
+    },
+    "suggest": {
+      "beberlei/assert": "Thin assertion library for input validation in business models. Used for tests."
+    },
+    "support": {
+      "issues": "https://github.com/php-deal/framework/issues",
+      "source": "https://github.com/php-deal/framework",
+      "docs": "https://github.com/php-deal/framework/blob/master/README.md"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "roave/security-advisories": "dev-master",
         "slevomat/coding-standard": "^4.8",
         "squizlabs/php_codesniffer": "^3.4",
-        "symfony/console": "~2.7|~3.0"
+        "symfony/console": "~2.7|~3.0|~4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,11 @@
     "description": "Design by Contract framework for PHP",
     "require": {
         "php": "^7.2",
-        "goaop/framework": "~2.0"
+        "goaop/framework": "^2.3"
     },
     "require-dev": {
         "beberlei/assert": "~3.0",
+        "phpstan/phpstan": "^0.11.0",
         "phpunit/phpunit": "^7.5",
         "roave/security-advisories": "dev-master",
         "slevomat/coding-standard": "^4.8",
@@ -38,11 +39,13 @@
         }
     },
     "scripts": {
+        "phpstan": "phpstan analyze",
         "phpcs": "phpcs src tests -sp --colors",
         "phpunit": "phpunit --verbose --colors=always",
         "test": [
-            "@phpunit",
-            "@phpcs"
+            "@phpstan",
+            "@phpcs",
+            "@phpunit"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,16 @@
     "name": "php-deal/framework",
     "description": "Design by Contract framework for PHP",
     "require": {
-        "php": "~7.0",
+        "php": "^7.2",
         "goaop/framework": "~2.0"
     },
     "require-dev": {
-        "symfony/console": "~2.7|~3.0",
-        "phpunit/phpunit": "^5.7",
-        "beberlei/assert": "~3.0"
+        "beberlei/assert": "~3.0",
+        "phpunit/phpunit": "^7.5",
+        "roave/security-advisories": "dev-master",
+        "slevomat/coding-standard": "^4.8",
+        "squizlabs/php_codesniffer": "^3.4",
+        "symfony/console": "~2.7|~3.0"
     },
     "license": "MIT",
     "authors": [
@@ -22,18 +25,35 @@
         }
     ],
     "autoload": {
-        "psr-4": {"PhpDeal\\": "src/"}
+        "psr-4": {
+            "PhpDeal\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-0": {"Demo\\": "demo/"},
-        "psr-4": {"PhpDeal\\": "tests/"}
+        "psr-0": {
+            "Demo\\": "demo/"
+        },
+        "psr-4": {
+            "PhpDeal\\": "tests/"
+        }
+    },
+    "scripts": {
+        "phpcs": "phpcs src tests -sp --colors",
+        "phpunit": "phpunit --verbose --colors=always",
+        "test": [
+            "@phpunit",
+            "@phpcs"
+        ]
+    },
+    "config": {
+        "sort-packages": true
     },
     "suggest": {
-      "beberlei/assert": "Thin assertion library for input validation in business models. Used for tests."
+        "beberlei/assert": "Thin assertion library for input validation in business models. Used for tests."
     },
     "support": {
-      "issues": "https://github.com/php-deal/framework/issues",
-      "source": "https://github.com/php-deal/framework",
-      "docs": "https://github.com/php-deal/framework/blob/master/README.md"
+        "issues": "https://github.com/php-deal/framework/issues",
+        "source": "https://github.com/php-deal/framework",
+        "docs": "https://github.com/php-deal/framework/blob/master/README.md"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         {
             "name": "Piotr Dawidiuk",
             "email": "piotr.dawidiuk@gmail.com"
+        },
+        {
+            "name": "Andreas Frömer",
+            "email": "blubb0r05+github@gmail.com"
         }
     ],
     "autoload": {

--- a/demo/Demo/Account.php
+++ b/demo/Demo/Account.php
@@ -14,7 +14,7 @@ use PhpDeal\Annotation as Contract;
 
 /**
  * Simple trade account class
- * @Contract\Invariant("$this->balance > 0")
+ * @Contract\Invariant("$this->balance >= 0")
  */
 class Account implements AccountContractInterface
 {
@@ -40,9 +40,19 @@ class Account implements AccountContractInterface
     }
 
     /**
+     * @Contract\Inherit()
+     * @param float $amount
+     */
+    public function withdraw($amount)
+    {
+        $this->balance -= $amount;
+    }
+
+    /**
      * Returns current balance
      *
      * @Contract\Ensure("$__result == $this->balance")
+     *
      * @return float
      */
     public function getBalance()

--- a/demo/Demo/Account.php
+++ b/demo/Demo/Account.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *

--- a/demo/Demo/Account.php
+++ b/demo/Demo/Account.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.

--- a/demo/Demo/AccountContractInterface.php
+++ b/demo/Demo/AccountContractInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *

--- a/demo/Demo/AccountContractInterface.php
+++ b/demo/Demo/AccountContractInterface.php
@@ -28,6 +28,17 @@ interface AccountContractInterface
     public function deposit($amount);
 
     /**
+     * Withdraw amount of money from account.
+     *
+     * We don't allow withdrawal of more than 50
+     * @Contract\Verify("$amount <= $this->balance")
+     * @Contract\Verify("$amount <= 50")
+     * @Contract\Ensure("$this->balance == $__old->balance-$amount")
+     * @param float $amount
+     */
+    public function withdraw($amount);
+
+    /**
      * Returns current balance
      *
      * @Contract\Ensure("$__result == $this->balance")

--- a/demo/Demo/AccountContractInterface.php
+++ b/demo/Demo/AccountContractInterface.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.

--- a/demo/aspect_bootstrap.php
+++ b/demo/aspect_bootstrap.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *

--- a/demo/aspect_bootstrap.php
+++ b/demo/aspect_bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
@@ -18,6 +20,6 @@ echo 'Deposit: 100' . PHP_EOL;
 $account->deposit(100);
 echo 'Current balance: ' . $account->getBalance();
 echo PHP_EOL;
-echo 'Withdraw: 100' . PHP_EOL;
+echo 'Withdraw: 50' . PHP_EOL;
 $account->withdraw(50);
 echo 'Current balance: ' . $account->getBalance();

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -13,5 +13,11 @@ include __DIR__.'/../vendor/autoload.php';
 include_once __DIR__.'/aspect_bootstrap.php';
 
 $account = new Demo\Account();
+
+echo 'Deposit: 100' . PHP_EOL;
 $account->deposit(100);
-echo $account->getBalance();
+echo 'Current balance: ' . $account->getBalance();
+echo PHP_EOL;
+echo 'Withdraw: 100' . PHP_EOL;
+$account->withdraw(50);
+echo 'Current balance: ' . $account->getBalance();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="PSR12-phpdeal">
+    <description>PSR-12 with native function invocation</description>
+    <!-- Add slevomat/coding-standard to installed_paths so we can use a single sniff -->
+    <config name="installed_paths" value="../../slevomat/coding-standard"/>
+
+    <exclude-pattern>*/cache</exclude-pattern>
+
+    <rule ref="PSR12"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+    excludes_analyse:
+        - %rootDir%/../../../tests/cache
+    level: max
+    paths:
+        - src/
+        - tests/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./tests/bootstrap.php"
         >
     <php>

--- a/src/Annotation/Ensure.php
+++ b/src/Annotation/Ensure.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,7 +21,7 @@ use Doctrine\Common\Annotations\Annotation as BaseAnnotation;
  */
 class Ensure extends BaseAnnotation
 {
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }

--- a/src/Annotation/Inherit.php
+++ b/src/Annotation/Inherit.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * PHP Deal framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace PhpDeal\Annotation;
+
+use Doctrine\Common\Annotations\Annotation as BaseAnnotation;
+
+/**
+ * This annotation defines a contract inheritance check, applied to the method or class
+ *
+ * @Annotation
+ * @Target({"METHOD", "CLASS"})
+ */
+class Inherit extends BaseAnnotation
+{
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/Annotation/Invariant.php
+++ b/src/Annotation/Invariant.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,7 +21,7 @@ use Doctrine\Common\Annotations\Annotation as BaseAnnotation;
  */
 class Invariant extends BaseAnnotation
 {
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }

--- a/src/Annotation/Verify.php
+++ b/src/Annotation/Verify.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Aspect/AbstractContractAspect.php
+++ b/src/Aspect/AbstractContractAspect.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -36,8 +38,9 @@ abstract class AbstractContractAspect
      *
      * @param MethodInvocation $invocation
      * @return array
+     * @throws \ReflectionException
      */
-    protected function fetchMethodArguments(MethodInvocation $invocation)
+    protected function fetchMethodArguments(MethodInvocation $invocation): array
     {
         $result         = [];
         $parameters     = $invocation->getMethod()->getParameters();
@@ -45,13 +48,12 @@ abstract class AbstractContractAspect
 
         // Number of arguments can be less than number of parameters because of default values
         foreach ($parameters as $parameterIndex => $reflectionParameter) {
-            $hasArgumentValue = array_key_exists($parameterIndex, $argumentValues);
+            $hasArgumentValue = \array_key_exists($parameterIndex, $argumentValues);
             $argumentValue    = $hasArgumentValue ? $argumentValues[$parameterIndex] : null;
             if (!$hasArgumentValue && $reflectionParameter->isDefaultValueAvailable()) {
                 $argumentValue = $reflectionParameter->getDefaultValue();
             }
             $result[$reflectionParameter->name] = $argumentValue;
-
         }
 
         return $result;
@@ -69,18 +71,23 @@ abstract class AbstractContractAspect
      * @throws DomainException
      * @throws ContractViolation
      */
-    protected function ensureContracts(MethodInvocation $invocation, array $contracts, $instance, $scope, array $args)
-    {
+    protected function ensureContracts(
+        MethodInvocation $invocation,
+        array $contracts,
+        $instance,
+        string $scope,
+        array $args
+    ): void {
         static $invoker = null;
         if (!$invoker) {
             $invoker = function () {
-                extract(func_get_arg(0));
+                \extract(\func_get_arg(0), EXTR_OVERWRITE);
 
-                return eval('return ' . func_get_arg(1) . '; ?>');
+                return eval('return ' . \func_get_arg(1) . '; ?>');
             };
         }
 
-        $instance     = is_object($instance) ? $instance : null;
+        $instance     = \is_object($instance) ? $instance : null;
         $boundInvoker = $invoker->bindTo($instance, $scope);
 
         foreach ($contracts as $contract) {
@@ -99,7 +106,6 @@ abstract class AbstractContractAspect
                         . ' only boolean or void can be returned';
                     throw new DomainException($errorMessage);
                 }
-
             } catch (\Error $internalError) {
                 // PHP-7 friendly interceptor for fatal errors
                 throw new ContractViolation($invocation, $contractExpression, $internalError);

--- a/src/Aspect/AbstractContractAspect.php
+++ b/src/Aspect/AbstractContractAspect.php
@@ -67,6 +67,7 @@ abstract class AbstractContractAspect
      * @param array $args List of arguments for the method
      *
      * @throws DomainException
+     * @throws ContractViolation
      */
     protected function ensureContracts(MethodInvocation $invocation, array $contracts, $instance, $scope, array $args)
     {
@@ -86,6 +87,10 @@ abstract class AbstractContractAspect
             $contractExpression = $contract->value;
             try {
                 $invocationResult = $boundInvoker->__invoke($args, $contractExpression);
+
+//                if ($invocationResult === false) {
+//                    throw new ContractViolation($invocation, $contractExpression);
+//                }
 
                 // we accept as a result only true or null
                 // null may be a result of assertions from beberlei/assert which passed

--- a/src/Aspect/AbstractContractAspect.php
+++ b/src/Aspect/AbstractContractAspect.php
@@ -96,9 +96,9 @@ abstract class AbstractContractAspect
             try {
                 $invocationResult = $boundInvoker->__invoke($args, $contractExpression);
 
-//                if ($invocationResult === false) {
-//                    throw new ContractViolation($invocation, $contractExpression);
-//                }
+                if ($invocationResult === false) {
+                    throw new ContractViolation($invocation, $contractExpression);
+                }
 
                 // we accept as a result only true or null
                 // null may be a result of assertions from beberlei/assert which passed

--- a/src/Aspect/AbstractContractAspect.php
+++ b/src/Aspect/AbstractContractAspect.php
@@ -81,7 +81,8 @@ abstract class AbstractContractAspect
         static $invoker = null;
         if (!$invoker) {
             $invoker = function () {
-                \extract(\func_get_arg(0), EXTR_OVERWRITE);
+                $args = \func_get_arg(0);
+                \extract($args, EXTR_OVERWRITE);
 
                 return eval('return ' . \func_get_arg(1) . '; ?>');
             };

--- a/src/Aspect/InheritCheckerAspect.php
+++ b/src/Aspect/InheritCheckerAspect.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace PhpDeal\Aspect;
+
+use Doctrine\Common\Annotations\Reader;
+use Go\Aop\Aspect;
+use Go\Aop\Intercept\MethodInvocation;
+use Go\Lang\Annotation\Around;
+use PhpDeal\Annotation\Ensure;
+use PhpDeal\Annotation\Invariant;
+use PhpDeal\Annotation\Verify;
+use PhpDeal\Contract\Fetcher\Parent\InvariantFetcher;
+use PhpDeal\Contract\Fetcher\Parent\MethodConditionFetcher;
+use PhpDeal\Exception\ContractViolation;
+use ReflectionClass;
+
+class InheritCheckerAspect extends AbstractContractAspect implements Aspect
+{
+    /**
+     * @var MethodConditionFetcher
+     */
+    private $methodConditionFetcher;
+
+    /** @var InvariantFetcher */
+    private $invariantFetcher;
+
+    public function __construct(Reader $reader)
+    {
+        parent::__construct($reader);
+        $this->methodConditionFetcher = new MethodConditionFetcher([Ensure::class, Verify::class, Invariant::class], $reader);
+        $this->invariantFetcher = new InvariantFetcher([Invariant::class], $reader);
+    }
+
+    /**
+     * Verifies inherit contracts for the method
+     *
+     * @Around("@execution(PhpDeal\Annotation\Inherit)")
+     * @param MethodInvocation $invocation
+     *
+     * @throws ContractViolation
+     * @return mixed
+     */
+    public function inheritMethodContracts(MethodInvocation $invocation)
+    {
+        $object = $invocation->getThis();
+        $args   = $this->fetchMethodArguments($invocation);
+        $class  = $invocation->getMethod()->getDeclaringClass();
+        if ($class->isCloneable()) {
+            $args['__old'] = clone $object;
+        }
+
+        $result = $invocation->proceed();
+        $args['__result'] = $result;
+        $allContracts = $this->fetchMethodContracts($invocation);
+
+        $this->ensureContracts($invocation, $allContracts, $object, $class->name, $args);
+
+        return $result;
+    }
+
+    /**
+     * @Around("@within(PhpDeal\Annotation\Inherit) && execution(public **->*(*))")
+     * @param MethodInvocation $invocation
+     * @return mixed
+     */
+    public function inheritClassContracts(MethodInvocation $invocation)
+    {
+        $object = $invocation->getThis();
+        $args   = $this->fetchMethodArguments($invocation);
+        $class  = $invocation->getMethod()->getDeclaringClass();
+        if ($class->isCloneable()) {
+            $args['__old'] = clone $object;
+        }
+
+        $result = $invocation->proceed();
+        $args['__result'] = $result;
+
+        $allContracts = $this->fetchClassContracts($class);
+        $this->ensureContracts($invocation, $allContracts, $object, $class->name, $args);
+
+        return $result;
+    }
+
+    /**
+     * @param MethodInvocation $invocation
+     * @return array
+     */
+    private function fetchMethodContracts(MethodInvocation $invocation)
+    {
+        $allContracts = $this->fetchParentsMethodContracts($invocation);
+
+        foreach ($invocation->getMethod()->getAnnotations() as $annotation) {
+            $annotationClass = \get_class($annotation);
+
+            if (\in_array($annotationClass, [Ensure::class, Verify::class, Invariant::class], true)) {
+                $allContracts[] = $annotation;
+            }
+        }
+
+        return array_unique($allContracts);
+    }
+
+    /**
+     * @param MethodInvocation $invocation
+     * @return array
+     */
+    private function fetchParentsMethodContracts(MethodInvocation $invocation)
+    {
+        return $this->methodConditionFetcher->getConditions(
+            $invocation->getMethod()->getDeclaringClass(),
+            $invocation->getMethod()->name
+        );
+    }
+
+    /**
+     * @param ReflectionClass $class
+     * @return array
+     */
+    private function fetchClassContracts(ReflectionClass $class)
+    {
+        $allContracts = $this->invariantFetcher->getConditions($class);
+        foreach ($this->reader->getClassAnnotations($class) as $annotation) {
+            if ($annotation instanceof Invariant) {
+                $allContracts[] = $annotation;
+            }
+        }
+
+        return array_unique($allContracts);
+    }
+}

--- a/src/Aspect/InvariantCheckerAspect.php
+++ b/src/Aspect/InvariantCheckerAspect.php
@@ -29,7 +29,7 @@ class InvariantCheckerAspect extends AbstractContractAspect implements Aspect
     public function __construct(Reader $reader)
     {
         parent::__construct($reader);
-        $this->invariantFetcher = new InvariantFetcher(Invariant::class, $reader);
+        $this->invariantFetcher = new InvariantFetcher([Invariant::class], $reader);
     }
 
     /**

--- a/src/Aspect/InvariantCheckerAspect.php
+++ b/src/Aspect/InvariantCheckerAspect.php
@@ -49,7 +49,7 @@ class InvariantCheckerAspect extends AbstractContractAspect implements Aspect
         $object = $invocation->getThis();
         $args   = $this->fetchMethodArguments($invocation);
         $class  = $invocation->getMethod()->getDeclaringClass();
-        if ($class->isCloneable()) {
+        if (\is_object($object) && $class->isCloneable()) {
             $args['__old'] = clone $object;
         }
 

--- a/src/Aspect/InvariantCheckerAspect.php
+++ b/src/Aspect/InvariantCheckerAspect.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -39,6 +41,7 @@ class InvariantCheckerAspect extends AbstractContractAspect implements Aspect
      * @param MethodInvocation $invocation
      *
      * @throws ContractViolation
+     * @throws \ReflectionException
      * @return mixed
      */
     public function invariantContract(MethodInvocation $invocation)
@@ -63,7 +66,7 @@ class InvariantCheckerAspect extends AbstractContractAspect implements Aspect
      * @param ReflectionClass $class
      * @return array
      */
-    private function fetchAllContracts(ReflectionClass $class)
+    private function fetchAllContracts(ReflectionClass $class): array
     {
         $allContracts = $this->invariantFetcher->getConditions($class);
         foreach ($this->reader->getClassAnnotations($class) as $annotation) {
@@ -72,6 +75,6 @@ class InvariantCheckerAspect extends AbstractContractAspect implements Aspect
             }
         }
 
-        return array_unique($allContracts);
+        return \array_unique($allContracts);
     }
 }

--- a/src/Aspect/PostconditionCheckerAspect.php
+++ b/src/Aspect/PostconditionCheckerAspect.php
@@ -28,7 +28,7 @@ class PostconditionCheckerAspect extends AbstractContractAspect implements Aspec
     public function __construct(Reader $reader)
     {
         parent::__construct($reader);
-        $this->methodConditionFetcher = new MethodConditionFetcher(Ensure::class, $reader);
+        $this->methodConditionFetcher = new MethodConditionFetcher([Ensure::class], $reader);
     }
 
     /**

--- a/src/Aspect/PostconditionCheckerAspect.php
+++ b/src/Aspect/PostconditionCheckerAspect.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -38,6 +40,7 @@ class PostconditionCheckerAspect extends AbstractContractAspect implements Aspec
      * @param MethodInvocation $invocation
      *
      * @throws ContractViolation
+     * @throws \ReflectionException
      * @return mixed
      */
     public function postConditionContract(MethodInvocation $invocation)
@@ -61,8 +64,9 @@ class PostconditionCheckerAspect extends AbstractContractAspect implements Aspec
     /**
      * @param MethodInvocation $invocation
      * @return array
+     * @throws \ReflectionException
      */
-    private function fetchAllContracts(MethodInvocation $invocation)
+    private function fetchAllContracts(MethodInvocation $invocation): array
     {
         $allContracts = $this->fetchParentsContracts($invocation);
         foreach ($invocation->getMethod()->getAnnotations() as $annotation) {
@@ -71,14 +75,15 @@ class PostconditionCheckerAspect extends AbstractContractAspect implements Aspec
             }
         }
 
-        return array_unique($allContracts);
+        return \array_unique($allContracts);
     }
 
     /**
      * @param MethodInvocation $invocation
      * @return array
+     * @throws \ReflectionException
      */
-    private function fetchParentsContracts(MethodInvocation $invocation)
+    private function fetchParentsContracts(MethodInvocation $invocation): array
     {
         return $this->methodConditionFetcher->getConditions(
             $invocation->getMethod()->getDeclaringClass(),

--- a/src/Aspect/PreconditionCheckerAspect.php
+++ b/src/Aspect/PreconditionCheckerAspect.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -39,7 +41,7 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
      *
      * @throws ContractViolation
      */
-    public function preConditionContract(MethodInvocation $invocation)
+    public function preConditionContract(MethodInvocation $invocation): void
     {
         $object = $invocation->getThis();
         $args   = $this->fetchMethodArguments($invocation);
@@ -53,7 +55,7 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
      * @param MethodInvocation $invocation
      * @return array
      */
-    private function fetchAllContracts(MethodInvocation $invocation)
+    private function fetchAllContracts(MethodInvocation $invocation): array
     {
         $allContracts = $this->fetchParentsContracts($invocation);
 
@@ -63,14 +65,14 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
             }
         }
 
-        return array_unique($allContracts);
+        return \array_unique($allContracts);
     }
 
     /**
      * @param MethodInvocation $invocation
      * @return array
      */
-    private function fetchParentsContracts(MethodInvocation $invocation)
+    private function fetchParentsContracts(MethodInvocation $invocation): array
     {
         return $this->methodConditionFetcher->getConditions(
             $invocation->getMethod()->getDeclaringClass(),

--- a/src/Aspect/PreconditionCheckerAspect.php
+++ b/src/Aspect/PreconditionCheckerAspect.php
@@ -28,7 +28,7 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
     public function __construct(Reader $reader)
     {
         parent::__construct($reader);
-        $this->methodConditionFetcher = new MethodConditionWithInheritDocFetcher(Verify::class, $reader);
+        $this->methodConditionFetcher = new MethodConditionWithInheritDocFetcher([Verify::class], $reader);
     }
 
     /**

--- a/src/Aspect/PreconditionCheckerAspect.php
+++ b/src/Aspect/PreconditionCheckerAspect.php
@@ -15,10 +15,13 @@ namespace PhpDeal\Aspect;
 use Doctrine\Common\Annotations\Reader;
 use Go\Aop\Aspect;
 use Go\Aop\Intercept\MethodInvocation;
+use Go\Aop\Support\AnnotatedReflectionMethod;
 use PhpDeal\Annotation\Verify;
 use PhpDeal\Contract\Fetcher\Parent\MethodConditionWithInheritDocFetcher;
 use PhpDeal\Exception\ContractViolation;
 use Go\Lang\Annotation\Before;
+use ReflectionException;
+use ReflectionMethod;
 
 class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
 {
@@ -40,6 +43,7 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
      * @Before("@execution(PhpDeal\Annotation\Verify)")
      *
      * @throws ContractViolation
+     * @throws ReflectionException
      */
     public function preConditionContract(MethodInvocation $invocation): void
     {
@@ -54,12 +58,15 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
     /**
      * @param MethodInvocation $invocation
      * @return array
+     * @throws ReflectionException
      */
     private function fetchAllContracts(MethodInvocation $invocation): array
     {
         $allContracts = $this->fetchParentsContracts($invocation);
+        /** @var ReflectionMethod&AnnotatedReflectionMethod $reflectionMethod */
+        $reflectionMethod = $invocation->getMethod();
 
-        foreach ($invocation->getMethod()->getAnnotations() as $annotation) {
+        foreach ($reflectionMethod->getAnnotations() as $annotation) {
             if ($annotation instanceof Verify) {
                 $allContracts[] = $annotation;
             }
@@ -71,6 +78,7 @@ class PreconditionCheckerAspect extends AbstractContractAspect implements Aspect
     /**
      * @param MethodInvocation $invocation
      * @return array
+     * @throws ReflectionException
      */
     private function fetchParentsContracts(MethodInvocation $invocation): array
     {

--- a/src/Contract/Fetcher/Parent/AbstractFetcher.php
+++ b/src/Contract/Fetcher/Parent/AbstractFetcher.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -28,7 +30,7 @@ abstract class AbstractFetcher
      * @param string[] $expectedAnnotationTypes
      * @param Reader   $reader
      */
-    public function __construct($expectedAnnotationTypes, Reader $reader)
+    public function __construct(array $expectedAnnotationTypes, Reader $reader)
     {
         $this->expectedAnnotationTypes = $expectedAnnotationTypes;
         $this->annotationReader        = $reader;
@@ -40,7 +42,7 @@ abstract class AbstractFetcher
      * @param array $annotations
      * @return array
      */
-    protected function filterContractAnnotation(array $annotations)
+    protected function filterContractAnnotation(array $annotations): array
     {
         $contractAnnotations = [];
 

--- a/src/Contract/Fetcher/Parent/AbstractFetcher.php
+++ b/src/Contract/Fetcher/Parent/AbstractFetcher.php
@@ -15,9 +15,9 @@ use Doctrine\Common\Annotations\Reader;
 abstract class AbstractFetcher
 {
     /**
-     * @var string
+     * @var string[]
      */
-    protected $expectedAnnotationType;
+    protected $expectedAnnotationTypes;
 
     /**
      * @var Reader
@@ -25,13 +25,13 @@ abstract class AbstractFetcher
     protected $annotationReader;
 
     /**
-     * @param string $expectedAnnotationType
-     * @param Reader $reader
+     * @param string[] $expectedAnnotationTypes
+     * @param Reader   $reader
      */
-    public function __construct($expectedAnnotationType, Reader $reader)
+    public function __construct($expectedAnnotationTypes, Reader $reader)
     {
-        $this->expectedAnnotationType = $expectedAnnotationType;
-        $this->annotationReader       = $reader;
+        $this->expectedAnnotationTypes = $expectedAnnotationTypes;
+        $this->annotationReader        = $reader;
     }
 
     /**
@@ -45,7 +45,9 @@ abstract class AbstractFetcher
         $contractAnnotations = [];
 
         foreach ($annotations as $annotation) {
-            if ($annotation instanceof $this->expectedAnnotationType) {
+            $annotationClass = \get_class($annotation);
+
+            if (\in_array($annotationClass, $this->expectedAnnotationTypes, true)) {
                 $contractAnnotations[] = $annotation;
             }
         }

--- a/src/Contract/Fetcher/Parent/InvariantFetcher.php
+++ b/src/Contract/Fetcher/Parent/InvariantFetcher.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -21,7 +23,7 @@ class InvariantFetcher extends AbstractFetcher
      *
      * @return array
      */
-    public function getConditions(ReflectionClass $class)
+    public function getConditions(ReflectionClass $class): array
     {
         $annotations   = [];
         $parents = [];
@@ -30,18 +32,21 @@ class InvariantFetcher extends AbstractFetcher
         $this->getInterfaces($class, $parents);
 
         foreach ($parents as $parent) {
-            $annotations = array_merge($annotations, $this->annotationReader->getClassAnnotations($parent));
+            $annotations[] = $this->annotationReader->getClassAnnotations($parent);
         }
-        $contracts = $this->filterContractAnnotation($annotations);
 
-        return $contracts;
+        if (\count($annotations)) {
+            $annotations = \array_merge(...$annotations);
+        }
+
+        return $this->filterContractAnnotation($annotations);
     }
 
     /**
      * @param ReflectionClass $class
      * @param array $parents
      */
-    private function getParentClasses(ReflectionClass $class, &$parents)
+    private function getParentClasses(ReflectionClass $class, array &$parents): void
     {
         while ($class = $class->getParentClass()) {
             $parents[] = $class;
@@ -52,11 +57,9 @@ class InvariantFetcher extends AbstractFetcher
      * @param ReflectionClass $class
      * @param array $parents
      */
-    private function getInterfaces(ReflectionClass $class, &$parents)
+    private function getInterfaces(ReflectionClass $class, array &$parents): void
     {
-        $interfaces = $class->getInterfaces();
-
-        foreach ($interfaces as $interface) {
+        foreach ($class->getInterfaces() as $interface) {
             $parents[] = $interface;
         }
     }

--- a/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
+++ b/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
@@ -52,9 +52,17 @@ class MethodConditionFetcher extends AbstractFetcher
      */
     private function getParentClassesMethods(ReflectionClass $class, string $methodName, array &$parentMethods): void
     {
-        while (($class = $class->getParentClass()) && $class->hasMethod($methodName)) {
-            $parentMethods[] = $class->getMethod($methodName);
+        $parent = $class->getParentClass();
+
+        if ($parent === false) {
+            return;
         }
+
+        if ($parent->hasMethod($methodName)) {
+            $parentMethods[] = $parent->getMethod($methodName);
+        }
+
+        $this->getParentClassesMethods($parent, $methodName, $parentMethods);
     }
 
     /**

--- a/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
+++ b/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,32 +20,37 @@ class MethodConditionFetcher extends AbstractFetcher
      * Fetches conditions from all parent method prototypes recursively
      *
      * @param ReflectionClass $class
-     * @param string $methodName
+     * @param string          $methodName
      *
      * @return array
+     * @throws \ReflectionException
      */
-    public function getConditions(ReflectionClass $class, $methodName)
+    public function getConditions(ReflectionClass $class, string $methodName): array
     {
-        $annotations   = [];
+        $annotations = [];
         $parentMethods = [];
 
         $this->getParentClassesMethods($class, $methodName, $parentMethods);
         $this->getInterfacesMethods($class, $methodName, $parentMethods);
 
         foreach ($parentMethods as $parentMethod) {
-            $annotations = array_merge($annotations, $this->annotationReader->getMethodAnnotations($parentMethod));
+            $annotations[] = $this->annotationReader->getMethodAnnotations($parentMethod);
         }
-        $contracts = $this->filterContractAnnotation($annotations);
 
-        return $contracts;
+        if (\count($annotations) > 0) {
+            $annotations = \array_merge(...$annotations);
+        }
+
+        return $this->filterContractAnnotation($annotations);
     }
 
     /**
      * @param ReflectionClass $class
-     * @param string $methodName
-     * @param array $parentMethods
+     * @param string          $methodName
+     * @param array           $parentMethods
+     * @throws \ReflectionException
      */
-    private function getParentClassesMethods(ReflectionClass $class, $methodName, &$parentMethods)
+    private function getParentClassesMethods(ReflectionClass $class, string $methodName, array &$parentMethods): void
     {
         while (($class = $class->getParentClass()) && $class->hasMethod($methodName)) {
             $parentMethods[] = $class->getMethod($methodName);
@@ -52,14 +59,13 @@ class MethodConditionFetcher extends AbstractFetcher
 
     /**
      * @param ReflectionClass $class
-     * @param string $methodName
-     * @param array $parentMethods
+     * @param string          $methodName
+     * @param array           $parentMethods
+     * @throws \ReflectionException
      */
-    private function getInterfacesMethods(ReflectionClass $class, $methodName, &$parentMethods)
+    private function getInterfacesMethods(ReflectionClass $class, $methodName, &$parentMethods): void
     {
-        $interfaces = $class->getInterfaces();
-
-        foreach ($interfaces as $interface) {
+        foreach ($class->getInterfaces() as $interface) {
             if ($interface->hasMethod($methodName)) {
                 $parentMethods[] = $interface->getMethod($methodName);
             }

--- a/src/Contract/Fetcher/Parent/MethodConditionWithInheritDocFetcher.php
+++ b/src/Contract/Fetcher/Parent/MethodConditionWithInheritDocFetcher.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace PhpDeal\Contract\Fetcher\Parent;
 
 use ReflectionClass;
+use ReflectionException;
 
 class MethodConditionWithInheritDocFetcher extends AbstractFetcher
 {
@@ -23,13 +24,19 @@ class MethodConditionWithInheritDocFetcher extends AbstractFetcher
      * @param string          $methodName
      *
      * @return array
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function getConditions(ReflectionClass $class, string $methodName): array
     {
         $annotations   = [];
         $parentMethods = [];
-        if (\preg_match('/\@inheritdoc/i', $class->getMethod($methodName)->getDocComment())) {
+        $docComment    = $class->getMethod($methodName)->getDocComment();
+
+        if ($docComment === false) {
+            return $annotations;
+        }
+
+        if (\preg_match('/\@inheritdoc/i', $docComment)) {
             $this->getParentClassesMethods($class, $methodName, $parentMethods);
             $this->getInterfacesMethods($class, $methodName, $parentMethods);
         }
@@ -49,20 +56,28 @@ class MethodConditionWithInheritDocFetcher extends AbstractFetcher
      * @param ReflectionClass $class
      * @param string          $methodName
      * @param array           $parentMethods
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function getParentClassesMethods(ReflectionClass $class, string $methodName, array &$parentMethods): void
     {
-        while (($class = $class->getParentClass()) && $class->hasMethod($methodName)) {
-            $parentMethods[] = $class->getMethod($methodName);
+        $parent = $class->getParentClass();
+
+        if ($parent === false) {
+            return;
         }
+
+        if ($parent->hasMethod($methodName)) {
+            $parentMethods[] = $parent->getMethod($methodName);
+        }
+
+        $this->getParentClassesMethods($parent, $methodName, $parentMethods);
     }
 
     /**
      * @param ReflectionClass $class
      * @param string          $methodName
      * @param array           $parentMethods
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function getInterfacesMethods(ReflectionClass $class, $methodName, &$parentMethods): void
     {

--- a/src/ContractApplication.php
+++ b/src/ContractApplication.php
@@ -11,6 +11,7 @@ namespace PhpDeal;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
+use PhpDeal\Aspect\InheritCheckerAspect;
 use PhpDeal\Aspect\InvariantCheckerAspect;
 use PhpDeal\Aspect\PostconditionCheckerAspect;
 use PhpDeal\Aspect\PreconditionCheckerAspect;
@@ -34,5 +35,6 @@ class ContractApplication extends AspectKernel
         $container->registerAspect(new InvariantCheckerAspect($reader));
         $container->registerAspect(new PostconditionCheckerAspect($reader));
         $container->registerAspect(new PreconditionCheckerAspect($reader));
+        $container->registerAspect(new InheritCheckerAspect($reader));
     }
 }

--- a/src/ContractApplication.php
+++ b/src/ContractApplication.php
@@ -1,17 +1,21 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
 namespace PhpDeal;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
 use PhpDeal\Aspect\InheritCheckerAspect;
+use Go\Core\GoAspectContainer;
 use PhpDeal\Aspect\InvariantCheckerAspect;
 use PhpDeal\Aspect\PostconditionCheckerAspect;
 use PhpDeal\Aspect\PreconditionCheckerAspect;
@@ -25,13 +29,15 @@ class ContractApplication extends AspectKernel
     /**
      * Configures an AspectContainer with advisors, aspects and pointcuts
      *
-     * @param AspectContainer $container
+     * @param AspectContainer&GoAspectContainer $container
      *
      * @return void
      */
-    protected function configureAop(AspectContainer $container)
+    protected function configureAop(AspectContainer $container): void
     {
+        /** @var AnnotationReader $reader */
         $reader = $container->get('aspect.annotation.reader');
+
         $container->registerAspect(new InvariantCheckerAspect($reader));
         $container->registerAspect(new PostconditionCheckerAspect($reader));
         $container->registerAspect(new PreconditionCheckerAspect($reader));

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -33,8 +33,9 @@ class ContractViolation extends \LogicException
         $obj        = $invocation->getThis();
         $objName    = \is_object($obj) ? \get_class($obj) : $obj;
         $method     = $invocation->getMethod();
+        $args       = implode(', ', $invocation->getArguments());
 
-        $message = "Contract {$contract} violated for {$objName}->{$method->name}";
+        $message = "Contract {$contract} violated with argument set {{$args}} for {$objName}->{$method->name}";
         parent::__construct($message, 0, $previous);
 
         $this->file = $method->getFileName();

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -33,7 +33,7 @@ class ContractViolation extends \LogicException
         $obj        = $invocation->getThis();
         $objName    = \is_object($obj) ? \get_class($obj) : $obj;
         $method     = $invocation->getMethod();
-        $args       = implode(', ', $invocation->getArguments());
+        $args       = \implode(', ', $invocation->getArguments());
 
         $message = "Contract {$contract} violated with argument set {{$args}} for {$objName}->{$method->name}";
         parent::__construct($message, 0, $previous);

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -28,10 +28,12 @@ class ContractViolation extends \LogicException
      */
     public function __construct(MethodInvocation $invocation, $contract, Exception $previous = null)
     {
-        $obj        = $invocation->getThis();
-        $objName    = is_object($obj) ? get_class($obj) : $obj;
-        $method     = $invocation->getMethod();
+        $obj       = $invocation->getThis();
+        $objName   = is_object($obj) ? get_class($obj) : $obj;
+        $method    = $invocation->getMethod();
+//        $arguments = implode(', ', $invocation->getArguments());
 
+//        $message = "Contract {$contract} violated with {$arguments} for {$objName}->{$method->name}";
         $message = "Contract {$contract} violated for {$objName}->{$method->name}";
         parent::__construct($message, 0, $previous);
 

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -28,17 +30,14 @@ class ContractViolation extends \LogicException
      */
     public function __construct(MethodInvocation $invocation, $contract, Exception $previous = null)
     {
-        $obj       = $invocation->getThis();
-        $objName   = is_object($obj) ? get_class($obj) : $obj;
-        $method    = $invocation->getMethod();
-//        $arguments = implode(', ', $invocation->getArguments());
+        $obj        = $invocation->getThis();
+        $objName    = \is_object($obj) ? \get_class($obj) : $obj;
+        $method     = $invocation->getMethod();
 
-//        $message = "Contract {$contract} violated with {$arguments} for {$objName}->{$method->name}";
         $message = "Contract {$contract} violated for {$objName}->{$method->name}";
         parent::__construct($message, 0, $previous);
 
         $this->file = $method->getFileName();
         $this->line = $method->getStartLine() + 1;
     }
-
 }

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace PhpDeal\Exception;
 
-use Exception;
 use Go\Aop\Intercept\MethodInvocation;
+use Throwable;
 
 /**
  * Specific contract violation exception to point to the file and line of invocation
@@ -26,9 +26,9 @@ class ContractViolation extends \LogicException
      *
      * @param MethodInvocation $invocation Current method invocation
      * @param string $contract Violated contract code
-     * @param Exception $previous
+     * @param Throwable $previous
      */
-    public function __construct(MethodInvocation $invocation, $contract, Exception $previous = null)
+    public function __construct(MethodInvocation $invocation, $contract, Throwable $previous = null)
     {
         $obj        = $invocation->getThis();
         $objName    = \is_object($obj) ? \get_class($obj) : $obj;

--- a/tests/Functional/Ensure/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Ensure/ClassPropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Ensure\ClassPropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerEnsureValid()
+    public function providerEnsureValid(): array
     {
         return [
             [
@@ -45,12 +50,13 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $variable
      * @dataProvider providerEnsureValid
      */
-    public function testEnsureValid($variable)
+    public function testEnsureValid(int $variable): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($variable);
     }
 
-    public function providerEnsureInvalid()
+    public function providerEnsureInvalid(): array
     {
         return [
             [
@@ -71,10 +77,10 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $variable
      * @dataProvider providerEnsureInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testEnsureInvalid($variable)
+    public function testEnsureInvalid(int $variable): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($variable);
     }
 }

--- a/tests/Functional/Ensure/ClassPropagation/Stub.php
+++ b/tests/Functional/Ensure/ClassPropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -16,8 +18,9 @@ class Stub extends StubParent
 {
     /**
      * @Contract\Ensure("$this->value !== 1")
+     * @param int $variable
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
         $this->value += $variable;
     }

--- a/tests/Functional/Ensure/ClassPropagation/StubGrandparent.php
+++ b/tests/Functional/Ensure/ClassPropagation/StubGrandparent.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -21,9 +23,9 @@ class StubGrandparent
 
     /**
      * @Contract\Ensure("$this->value !== -1")
+     * @param int $variable
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Ensure/ClassPropagation/StubParent.php
+++ b/tests/Functional/Ensure/ClassPropagation/StubParent.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -16,8 +18,9 @@ abstract class StubParent extends StubGrandparent
 {
     /**
      * @Contract\Ensure("$this->value !== 2")
+     * @param int $variable
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
         $this->value += $variable;
     }

--- a/tests/Functional/Ensure/ContractTest.php
+++ b/tests/Functional/Ensure/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,7 +12,10 @@
 
 namespace PhpDeal\Functional\Ensure;
 
-class ContractTest extends \PHPUnit_Framework_TestCase
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -29,29 +34,27 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function testEnsureValid()
+    public function testEnsureValid(): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->increment(50);
     }
 
-    /**
-     * @expectedException \PhpDeal\Exception\ContractViolation
-     */
-    public function testEnsureManyContractsInvalid()
+    public function testEnsureManyContractsInvalid(): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->increment(-50);
     }
 
-    /**
-     * @expectedException \PhpDeal\Exception\ContractViolation
-     */
-    public function testEnsureInvalid()
+    public function testEnsureInvalid(): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->badIncrement(40);
     }
 
-    public function testEnsureCanHandleResult()
+    public function testEnsureCanHandleResult(): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->returnPrivateValue();
     }
 }

--- a/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Ensure\InterfacePropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerEnsureValid()
+    public function providerEnsureValid(): array
     {
         return [
             [
@@ -45,12 +50,13 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $variable
      * @dataProvider providerEnsureValid
      */
-    public function testEnsureValid($variable)
+    public function testEnsureValid(int $variable): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($variable);
     }
 
-    public function providerEnsureInvalid()
+    public function providerEnsureInvalid(): array
     {
         return [
             [
@@ -71,10 +77,10 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $variable
      * @dataProvider providerEnsureInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testEnsureInvalid($variable)
+    public function testEnsureInvalid(int $variable): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($variable);
     }
 }

--- a/tests/Functional/Ensure/InterfacePropagation/Stub.php
+++ b/tests/Functional/Ensure/InterfacePropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -23,7 +25,7 @@ class Stub implements StubInterfaceA, StubInterfaceB
      * @Contract\Ensure("$this->value !== 0")
      * @param int $variable
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
         $this->value += $variable;
     }

--- a/tests/Functional/Ensure/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Ensure/InterfacePropagation/StubInterfaceA.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
 
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,5 +20,5 @@ interface StubInterfaceA
      * @Contract\Ensure("$this->value !== -1")
      * @param int $variable
      */
-    public function add($variable);
+    public function add(int $variable): void;
 }

--- a/tests/Functional/Ensure/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Ensure/InterfacePropagation/StubInterfaceB.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
 
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,5 +20,5 @@ interface StubInterfaceB
      * @Contract\Ensure("$this->value !== -2")
      * @param int $variable
      */
-    public function add($variable);
+    public function add(int $variable): void;
 }

--- a/tests/Functional/Ensure/Stub.php
+++ b/tests/Functional/Ensure/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -21,10 +23,10 @@ class Stub
      * Method that changes internal state and ensures a contract for this
      * @param float $amount
      *
-     * @Contract\Ensure("$this->privateValue == $__old->privateValue + $amount")
+     * @Contract\Ensure("$this->privateValue === $__old->privateValue + $amount")
      * @Contract\Ensure("$this->privateValue > 0")
      */
-    public function increment($amount)
+    public function increment(float $amount): void
     {
         $this->privateValue += $amount;
     }
@@ -33,9 +35,9 @@ class Stub
      * BAD Method that changes internal state and ensures a contract for this
      * @param float $amount
      *
-     * @Contract\Ensure("$this->privateValue == $__old->privateValue + $amount")
+     * @Contract\Ensure("$this->privateValue === $__old->privateValue + $amount")
      */
-    public function badIncrement($amount)
+    public function badIncrement(float $amount): void
     {
         $this->privateValue += ($amount - 0.1); // Dirty hacker wants to earn money!
     }
@@ -43,9 +45,9 @@ class Stub
     /**
      * Let's check that this getter is not cheating
      *
-     * @Contract\Ensure("$__result == $this->privateValue")
+     * @Contract\Ensure("$__result === $this->privateValue")
      */
-    public function returnPrivateValue()
+    public function returnPrivateValue(): int
     {
         return $this->privateValue;
     }
@@ -53,11 +55,10 @@ class Stub
     /**
      * Let's check that aspect doesn't pay an attention to unknown annotations
      *
-     * @Contract\Ensure("$__result == $this->privateValue")
+     * @Contract\Ensure("$__result === $this->privateValue")
      * @Pointcut("")
      */
-    public function unknown()
+    public function unknown(): void
     {
-
     }
 }

--- a/tests/Functional/Inherit/ContractTest.php
+++ b/tests/Functional/Inherit/ContractTest.php
@@ -22,9 +22,8 @@ class ContractTest extends TestCase
         unset($this->stubWithoutInherit, $this->stubWithInherit);
     }
 
-    public function testWithoutInheritIsValid()
+    public function testWithoutInheritIsValid(): void
     {
-        $this->stubWithoutInherit->add("test");
         $this->stubWithoutInherit->add(0);
         $this->assertEquals(10, $this->stubWithoutInherit->getAmount());
     }
@@ -33,12 +32,12 @@ class ContractTest extends TestCase
      * @expectedException \PhpDeal\Exception\ContractViolation
      * @return void
      */
-    public function testWithInheritInvalid()
+    public function testWithInheritInvalid(): void
     {
         $this->stubWithInherit->add(0);
     }
 
-    public function testWithInheritValid()
+    public function testWithInheritValid(): void
     {
         $this->stubWithInherit->add(10);
         $this->assertEquals(10, $this->stubWithInherit->getAmount());

--- a/tests/Functional/Inherit/ContractTest.php
+++ b/tests/Functional/Inherit/ContractTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PhpDeal\Functional\Inherit;
+
+use PHPUnit\Framework\TestCase;
+
+class ContractTest extends TestCase
+{
+    /** @var StubWithoutInherit */
+    private $stubWithoutInherit;
+    /** @var StubWithInherit */
+    private $stubWithInherit;
+
+    public function setUp()
+    {
+        $this->stubWithoutInherit = new StubWithoutInherit();
+        $this->stubWithInherit = new StubWithInherit();
+    }
+
+    public function tearDown()
+    {
+        unset($this->stubWithoutInherit, $this->stubWithInherit);
+    }
+
+    public function testWithoutInheritIsValid()
+    {
+        $this->stubWithoutInherit->add("test");
+        $this->stubWithoutInherit->add(0);
+        $this->assertEquals(10, $this->stubWithoutInherit->getAmount());
+    }
+
+    /**
+     * @expectedException \PhpDeal\Exception\ContractViolation
+     * @return void
+     */
+    public function testWithInheritInvalid()
+    {
+        $this->stubWithInherit->add(0);
+    }
+
+    public function testWithInheritValid()
+    {
+        $this->stubWithInherit->add(10);
+        $this->assertEquals(10, $this->stubWithInherit->getAmount());
+    }
+}

--- a/tests/Functional/Inherit/StubInterface.php
+++ b/tests/Functional/Inherit/StubInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpDeal\Functional\Inherit;
+
+use PhpDeal\Annotation as Contract;
+
+interface StubInterface
+{
+    /**
+     * @Contract\Verify("$amount > 0 && is_numeric($amount)")
+     * @param integer $amount
+     * @return void
+     */
+    public function add($amount);
+
+    /**
+     * @Contract\Ensure("$__result === $this->amount")
+     */
+    public function getAmount();
+}

--- a/tests/Functional/Inherit/StubWithInherit.php
+++ b/tests/Functional/Inherit/StubWithInherit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpDeal\Functional\Inherit;
+
+use PhpDeal\Annotation as Contract;
+
+class StubWithInherit implements StubInterface
+{
+    private $amount = 0;
+
+    /**
+     * @Contract\Inherit()
+     * @param integer $amount
+     * @return void
+     */
+    public function add($amount)
+    {
+        $this->amount += $amount;
+    }
+
+    /**
+     * @Contract\Inherit()
+     * @return integer
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+}

--- a/tests/Functional/Inherit/StubWithoutInherit.php
+++ b/tests/Functional/Inherit/StubWithoutInherit.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpDeal\Functional\Inherit;
+
+class StubWithoutInherit implements StubInterface
+{
+    private $amount = 0;
+
+    public function add($amount)
+    {
+        $this->amount = $amount;
+    }
+
+    public function getAmount()
+    {
+        return 10;
+    }
+}

--- a/tests/Functional/Invariant/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Invariant/ClassPropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Invariant\ClassPropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerInvariantValid()
+    public function providerInvariantValid(): array
     {
         return [
             [
@@ -45,12 +50,13 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $variable
      * @dataProvider providerInvariantValid
      */
-    public function testInvariantValid($variable)
+    public function testInvariantValid(int $variable): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->setVariable($variable);
     }
 
-    public function providerInvariantInvalid()
+    public function providerInvariantInvalid(): array
     {
         return [
             [
@@ -71,10 +77,10 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $variable
      * @dataProvider providerInvariantInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testInvariantInvalid($variable)
+    public function testInvariantInvalid(int $variable): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->setVariable($variable);
     }
 }

--- a/tests/Functional/Invariant/ClassPropagation/Stub.php
+++ b/tests/Functional/Invariant/ClassPropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,19 +15,14 @@ namespace PhpDeal\Functional\Invariant\ClassPropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 1")
+ * @Contract\Invariant("$this->variable !== 1")
  */
 class Stub extends StubParent
 {
     /**
-     * @var int
-     */
-    public $variable;
-
-    /**
      * @param int $variable
      */
-    public function setVariable($variable)
+    public function setVariable(int $variable): void
     {
         $this->variable = $variable;
     }

--- a/tests/Functional/Invariant/ClassPropagation/StubGrandparent.php
+++ b/tests/Functional/Invariant/ClassPropagation/StubGrandparent.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,9 +13,12 @@ namespace PhpDeal\Functional\Invariant\ClassPropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 3")
+ * @Contract\Invariant("$this->variable !== 3")
  */
 abstract class StubGrandparent
 {
-
+    /**
+     * @var int
+     */
+    public $variable;
 }

--- a/tests/Functional/Invariant/ClassPropagation/StubParent.php
+++ b/tests/Functional/Invariant/ClassPropagation/StubParent.php
@@ -2,7 +2,7 @@
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,7 +13,7 @@ namespace PhpDeal\Functional\Invariant\ClassPropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 2")
+ * @Contract\Invariant("$this->variable !== 2")
  */
 abstract class StubParent extends StubGrandparent
 {

--- a/tests/Functional/Invariant/ContractTest.php
+++ b/tests/Functional/Invariant/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,7 +12,10 @@
 
 namespace PhpDeal\Functional\Invariant;
 
-class ContractTest extends \PHPUnit_Framework_TestCase
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -29,24 +34,21 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function testInvariantValid()
+    public function testInvariantValid(): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->accelerate(10, 30); // let's have a speed 300m/s
     }
 
-    /**
-     * @expectedException \PhpDeal\Exception\ContractViolation
-     */
-    public function testInvariantViolated()
+    public function testInvariantViolated(): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->accelerate(10, 3e7); // let's have a speed 3*1e8 m/s, faster than light!
     }
 
-    /**
-     * @expectedException \PhpDeal\Exception\ContractViolation
-     */
-    public function testInvariantViolatedAfterSeveralMethods()
+    public function testInvariantViolatedAfterSeveralMethods(): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->accelerate(10, 30); // let's have a speed 300m/s
         $this->stub->decelerate(20, 20); // Negative speed?
     }

--- a/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerInvariantValid()
+    public function providerInvariantValid(): array
     {
         return [
             [
@@ -45,12 +50,13 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $variable
      * @dataProvider providerInvariantValid
      */
-    public function testInvariantValid($variable)
+    public function testInvariantValid(int $variable): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->setVariable($variable);
     }
 
-    public function providerInvariantInvalid()
+    public function providerInvariantInvalid(): array
     {
         return [
             [
@@ -71,10 +77,10 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $variable
      * @dataProvider providerInvariantInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testInvariantInvalid($variable)
+    public function testInvariantInvalid($variable): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->setVariable($variable);
     }
 }

--- a/tests/Functional/Invariant/InterfacePropagation/Stub.php
+++ b/tests/Functional/Invariant/InterfacePropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,7 +15,7 @@ namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 1")
+ * @Contract\Invariant("$this->variable !== 1")
  */
 class Stub implements StubInterfaceA, StubInterfaceB
 {
@@ -25,7 +27,7 @@ class Stub implements StubInterfaceA, StubInterfaceB
     /**
      * @param int $variable
      */
-    public function setVariable($variable)
+    public function setVariable(int $variable)
     {
         $this->variable = $variable;
     }

--- a/tests/Functional/Invariant/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Invariant/InterfacePropagation/StubInterfaceA.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,7 +15,7 @@ namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 2")
+ * @Contract\Invariant("$this->variable !== 2")
  */
 interface StubInterfaceA
 {

--- a/tests/Functional/Invariant/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Invariant/InterfacePropagation/StubInterfaceB.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -13,7 +15,7 @@ namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 use PhpDeal\Annotation as Contract;
 
 /**
- * @Contract\Invariant("$this->variable != 3")
+ * @Contract\Invariant("$this->variable !== 3")
  */
 interface StubInterfaceB
 {

--- a/tests/Functional/Invariant/Stub.php
+++ b/tests/Functional/Invariant/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -27,9 +29,9 @@ class Stub
      * Accelerate
      *
      * @param float $acceleration
-     * @param integer $time
+     * @param float   $time
      */
-    public function accelerate($acceleration, $time)
+    public function accelerate(float $acceleration, float $time): void
     {
         $this->speed += ($acceleration * $time);
     }
@@ -38,9 +40,9 @@ class Stub
      * Decelerate
      *
      * @param float $decelaration
-     * @param integer $time
+     * @param float   $time
      */
-    public function decelerate($decelaration, $time)
+    public function decelerate(float $decelaration, float $time): void
     {
         $this->speed -= ($decelaration * $time);
     }

--- a/tests/Functional/Verify/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerVerifyInvalid()
+    public function providerVerifyInvalid(): array
     {
         return [
             [
@@ -45,14 +50,14 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $parameter
      * @dataProvider providerVerifyInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testVerifyInvalid($parameter)
+    public function testVerifyInvalid(int $parameter): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($parameter);
     }
 
-    public function providerVerifyValid()
+    public function providerVerifyValid(): array
     {
         return [
             [
@@ -66,8 +71,9 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $parameter
      * @dataProvider providerVerifyValid
      */
-    public function testVerifyValid($parameter)
+    public function testVerifyValid(int $parameter): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($parameter);
     }
 }

--- a/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,11 +12,14 @@
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  * @group inheritdoc
  */
-class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
+class ContractWithInheritDocTest extends TestCase
 {
     /**
      * @var StubWithInheritDoc
@@ -33,7 +38,7 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerVerifyInvalid()
+    public function providerVerifyInvalid(): array
     {
         return [
             [
@@ -54,14 +59,14 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $parameter
      * @dataProvider providerVerifyInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testVerifyInvalid($parameter)
+    public function testVerifyInvalid(int $parameter): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($parameter);
     }
 
-    public function providerVerifyValid()
+    public function providerVerifyValid(): array
     {
         return [
             [
@@ -74,8 +79,9 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
      * @param int $parameter
      * @dataProvider providerVerifyValid
      */
-    public function testVerifyValid($parameter)
+    public function testVerifyValid(int $parameter): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($parameter);
     }
 }

--- a/tests/Functional/Verify/ClassPropagation/Stub.php
+++ b/tests/Functional/Verify/ClassPropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,8 +20,7 @@ class Stub extends StubParent
      * @param int $variable
      * @Contract\Verify("$variable !== 1")
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Verify/ClassPropagation/StubGrandparent.php
+++ b/tests/Functional/Verify/ClassPropagation/StubGrandparent.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,8 +20,7 @@ class StubGrandparent
      * @param int $variable
      * @Contract\Verify("$variable !== 3")
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Verify/ClassPropagation/StubParent.php
+++ b/tests/Functional/Verify/ClassPropagation/StubParent.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,8 +20,7 @@ abstract class StubParent
      * @param int $variable
      * @Contract\Verify("$variable !== 2")
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Verify/ClassPropagation/StubParentWithInheritDoc.php
+++ b/tests/Functional/Verify/ClassPropagation/StubParentWithInheritDoc.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,8 +21,7 @@ abstract class StubParentWithInheritDoc extends StubGrandparent
      * @Contract\Verify("$variable !== 2")
      * @inheritdoc
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
-} 
+}

--- a/tests/Functional/Verify/ClassPropagation/StubWithInheritDoc.php
+++ b/tests/Functional/Verify/ClassPropagation/StubWithInheritDoc.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,8 +21,7 @@ class StubWithInheritDoc extends StubParentWithInheritDoc
      * @Contract\Verify("$variable !== 1")
      * {@inheritdoc}
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
-} 
+}

--- a/tests/Functional/Verify/ContractTest.php
+++ b/tests/Functional/Verify/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,7 +12,10 @@
 
 namespace PhpDeal\Functional\Verify;
 
-class ContractTest extends \PHPUnit_Framework_TestCase
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -29,87 +34,60 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function testVerifyValid()
+    public function testVerifyValid(): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->testNumeric(-200);
     }
 
-    /**
-     * @expectedException \PhpDeal\Exception\ContractViolation
-     */
-    public function testVerifyInvalid()
+    public function testAccessToPrivateFields(): void
     {
-        $this->stub->testNumeric('message');
-    }
-
-    public function testAccessToPrivateFields()
-    {
+        $this->expectNotToPerformAssertions();
         $this->stub->testAccessToPrivateField(50);
     }
 
-    public function testVerifyWithAssertValid()
+    public function testVerifyWithAssertValid(): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add(100);
     }
 
-    public function providerVerifyWithAssertInvalid()
-    {
-        return [
-            [
-                'value' => ""
-            ],
-            [
-                'value' => 5.5
-            ],
-            [
-                'value' => null
-            ],
-            [
-                'value' => []
-            ]
-        ];
-    }
-
     /**
-     * @param mixed $value
-     * @dataProvider providerVerifyWithAssertInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
+     * This test should fail with php TypeError.
      */
-    public function testVerifyWithAssertInvalid($value)
+    public function testVerifyWithAssertInvalid(): void
     {
-        $this->stub->add($value);
+        $this->expectException(ContractViolation::class);
+        $this->stub->add(1);
     }
 
-    public function testVerifyManyContractsValid()
+    public function testVerifyManyContractsValid(): void
     {
-        $this->stub->sub(10);
+        $this->expectNotToPerformAssertions();
+        $this->stub->sub(9);
     }
 
-    public function providerVerifyManyContractsInvalid()
+    public function providerVerifyManyContractsInvalid(): array
     {
         return [
             [
-                'value' => ""
+                'value' => 11
             ],
             [
                 'value' => 1
             ],
-            [
-                'value' => null
-            ],
-            [
-                'value' => []
-            ]
         ];
     }
 
     /**
-     * @param mixed $value
+     * This test should fail with php TypeError.
+     *
+     * @param mixed  $value
      * @dataProvider providerVerifyManyContractsInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testVerifyManyContractsInvalid($value)
+    public function testVerifyManyContractsInvalid($value): void
     {
-        $this->stub->sub($value);
+        $this->expectException(ContractViolation::class);
+        $this->stub->sub(1);
     }
 }

--- a/tests/Functional/Verify/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,10 +12,13 @@
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  */
-class ContractTest extends \PHPUnit_Framework_TestCase
+class ContractTest extends TestCase
 {
     /**
      * @var Stub
@@ -32,7 +37,7 @@ class ContractTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerVerifyInvalid()
+    public function providerVerifyInvalid(): array
     {
         return [
             [
@@ -45,22 +50,24 @@ class ContractTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $parameter
      * @dataProvider providerVerifyInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testVerifyInvalid($parameter)
+    public function testVerifyInvalid(int $parameter): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($parameter);
     }
 
-    public function providerVerifyValid()
+    public function providerVerifyValid(): array
     {
         return [
             [
-                // StubInterfaceA does not accept this parameter, but Stub accepts (and we don't have inheritdoc annotation)
+                // StubInterfaceA does not accept this parameter,
+                // but Stub accepts (and we don't have inheritdoc annotation)
                 'parameter' => 2
             ],
             [
-                // StubInterfaceB does not accept this parameter, but Stub accepts (and we don't have inheritdoc annotation)
+                // StubInterfaceB does not accept this parameter,
+                // but Stub accepts (and we don't have inheritdoc annotation)
                 'parameter' => 3
             ]
         ];
@@ -70,8 +77,9 @@ class ContractTest extends \PHPUnit_Framework_TestCase
      * @param int $parameter
      * @dataProvider providerVerifyValid
      */
-    public function testVerifyValid($parameter)
+    public function testVerifyValid(int $parameter): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($parameter);
     }
 }

--- a/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -10,11 +12,14 @@
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 
+use PhpDeal\Exception\ContractViolation;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group propagation
  * @group inheritdoc
  */
-class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
+class ContractWithInheritDocTest extends TestCase
 {
     /**
      * @var StubWithInheritDoc
@@ -33,7 +38,7 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function providerVerifyInvalid()
+    public function providerVerifyInvalid(): array
     {
         return [
             [
@@ -54,14 +59,14 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
     /**
      * @param int $parameter
      * @dataProvider providerVerifyInvalid
-     * @expectedException \PhpDeal\Exception\ContractViolation
      */
-    public function testVerifyInvalid($parameter)
+    public function testVerifyInvalid(int $parameter): void
     {
+        $this->expectException(ContractViolation::class);
         $this->stub->add($parameter);
     }
 
-    public function providerVerifyValid()
+    public function providerVerifyValid(): array
     {
         return [
             [
@@ -74,8 +79,9 @@ class ContractWithInheritDocTest extends \PHPUnit_Framework_TestCase
      * @param int $parameter
      * @dataProvider providerVerifyValid
      */
-    public function testVerifyValid($parameter)
+    public function testVerifyValid(int $parameter): void
     {
+        $this->expectNotToPerformAssertions();
         $this->stub->add($parameter);
     }
 }

--- a/tests/Functional/Verify/InterfacePropagation/Stub.php
+++ b/tests/Functional/Verify/InterfacePropagation/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,8 +20,7 @@ class Stub implements StubInterfaceA, StubInterfaceB
      * @param int $variable
      * @Contract\Verify("$variable !== 1")
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Verify/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubInterfaceA.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,5 +20,5 @@ interface StubInterfaceA
      * @param int $variable
      * @Contract\Verify("$variable !== 2")
      */
-    public function add($variable);
+    public function add(int $variable): void;
 }

--- a/tests/Functional/Verify/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubInterfaceB.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -18,5 +20,5 @@ interface StubInterfaceB
      * @param int $variable
      * @Contract\Verify("$variable !== 3")
      */
-    public function add($variable);
+    public function add(int $variable): void;
 }

--- a/tests/Functional/Verify/InterfacePropagation/StubWithInheritDoc.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubWithInheritDoc.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -19,8 +21,7 @@ class StubWithInheritDoc implements StubInterfaceA, StubInterfaceB
      * @Contract\Verify("$variable !== 1")
      * {@inheritdoc}
      */
-    public function add($variable)
+    public function add(int $variable): void
     {
-
     }
 }

--- a/tests/Functional/Verify/Stub.php
+++ b/tests/Functional/Verify/Stub.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 /**
  * PHP Deal framework
  *
- * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
  *
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
@@ -21,10 +23,10 @@ class Stub
      * Method with numeric parameter requirement
      *
      * @param float $variable
-     * @Contract\Verify("is_numeric($variable)")
+     * @Contract\Verify("\is_numeric($variable)")
      * @return float
      */
-    public function testNumeric($variable)
+    public function testNumeric(float $variable): float
     {
         return $variable;
     }
@@ -37,9 +39,8 @@ class Stub
      * @Contract\Verify("$variable > $this->privateValue")
      * @Pointcut("")
      */
-    public function testAccessToPrivateField($variable)
+    public function testAccessToPrivateField($variable): void
     {
-        return;
     }
 
     /**
@@ -47,9 +48,9 @@ class Stub
      *
      * @param int $value
      * @return bool
-     * @Contract\Verify("Assert\Assertion::integer($value)")
+     * @Contract\Verify("Assert\Assertion::greaterThan($value, 5)")
      */
-    public function add($value)
+    public function add(int $value): bool
     {
         return true;
     }
@@ -59,11 +60,11 @@ class Stub
      *
      * @param int $value
      * @return bool
-     * @Contract\Verify("is_numeric($value)")
+     * @Contract\Verify("$value < 10")
      * @Contract\Verify("$value > 5")
      */
-    public function sub($value)
+    public function sub(int $value): bool
     {
         return true;
     }
-} 
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,13 +1,10 @@
 <?php
+declare(strict_types=1);
 
 use PhpDeal\ContractApplication;
 
-if (!class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}
-
-ContractApplication::getInstance()->init(array(
+ContractApplication::getInstance()->init([
     'debug'    => true,
     'appDir'   => __DIR__,
-    'cacheDir' => __DIR__.'/cache/',
-));
+    'cacheDir' => __DIR__ . '/cache/',
+]);


### PR DESCRIPTION
This will bump phpdeal/framework to php7.2 and version 1.x.
The branch 1.x should replace master if this PR gets accepted.
0.x is only there for backward fixes, but can probably be dropped as well.

List of changes:
- drop support php < 7.2
- update phpunit to 7.5
- add strict types in all files
- add return type and argument type hinting in all files
- bump copyright to 2019