### PR TITLE
Updated beberlei/assert to version 3.x.x & PHP min version 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": ">=5.6.0",
         "goaop/framework": "~2.0",
-        "beberlei/assert": "^2.4"
+        "beberlei/assert": "~3.0"
     },
     "require-dev": {
         "symfony/console": "~2.7|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "php-deal/framework",
     "description": "Design by Contract framework for PHP",
     "require": {
-        "php": ">=7.0",
-        "goaop/framework": "~2.0",
-        "beberlei/assert": "~3.0"
+        "php": "~7.0",
+        "goaop/framework": "~2.0"
     },
     "require-dev": {
         "symfony/console": "~2.7|~3.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "beberlei/assert": "~3.0"
     },
     "license": "MIT",
     "authors": [
@@ -27,5 +27,13 @@
     "autoload-dev": {
         "psr-0": {"Demo\\": "demo/"},
         "psr-4": {"PhpDeal\\": "tests/"}
+    },
+    "suggest": {
+      "beberlei/assert": "Thin assertion library for input validation in business models. Used for tests."
+    },
+    "support": {
+      "issues": "https://github.com/php-deal/framework/issues",
+      "source": "https://github.com/php-deal/framework",
+      "docs": "https://github.com/php-deal/framework/blob/master/README.md"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "php-deal/framework",
     "description": "Design by Contract framework for PHP",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0",
         "goaop/framework": "~2.0",
         "beberlei/assert": "~3.0"
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/400362/51505167-bacd9280-1ded-11e9-95e0-4c653eeda715.png)

This is because I tried to require that library into one of my projects but I got:
![image](https://user-images.githubusercontent.com/400362/51505203-e0f33280-1ded-11e9-8158-5a76884edc70.png)

And also, why not update to the latest version since it does not break anything.