### PR TITLE
Fix PSR-12 coding style via PHP_CodeSniffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer install

--- a/src/Annotation/Ensure.php
+++ b/src/Annotation/Ensure.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Annotation;
 

--- a/src/Annotation/Invariant.php
+++ b/src/Annotation/Invariant.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Annotation;
 

--- a/src/Annotation/Verify.php
+++ b/src/Annotation/Verify.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Annotation;
 

--- a/src/Aspect/AbstractContractAspect.php
+++ b/src/Aspect/AbstractContractAspect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Aspect;
 

--- a/src/Aspect/InvariantCheckerAspect.php
+++ b/src/Aspect/InvariantCheckerAspect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Aspect;
 

--- a/src/Aspect/PostconditionCheckerAspect.php
+++ b/src/Aspect/PostconditionCheckerAspect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Aspect;
 

--- a/src/Aspect/PreconditionCheckerAspect.php
+++ b/src/Aspect/PreconditionCheckerAspect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Aspect;
 

--- a/src/Contract/Fetcher/Parent/AbstractFetcher.php
+++ b/src/Contract/Fetcher/Parent/AbstractFetcher.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Contract\Fetcher\Parent;
 

--- a/src/Contract/Fetcher/Parent/InvariantFetcher.php
+++ b/src/Contract/Fetcher/Parent/InvariantFetcher.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Contract\Fetcher\Parent;
 

--- a/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
+++ b/src/Contract/Fetcher/Parent/MethodConditionFetcher.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Contract\Fetcher\Parent;
 

--- a/src/Contract/Fetcher/Parent/MethodConditionWithInheritDocFetcher.php
+++ b/src/Contract/Fetcher/Parent/MethodConditionWithInheritDocFetcher.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Contract\Fetcher\Parent;
 

--- a/src/ContractApplication.php
+++ b/src/ContractApplication.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal;
 

--- a/src/Exception/ContractViolation.php
+++ b/src/Exception/ContractViolation.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Exception;
 

--- a/tests/Functional/Ensure/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Ensure/ClassPropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\ClassPropagation;
 

--- a/tests/Functional/Ensure/ClassPropagation/Stub.php
+++ b/tests/Functional/Ensure/ClassPropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\ClassPropagation;
 

--- a/tests/Functional/Ensure/ClassPropagation/StubGrandparent.php
+++ b/tests/Functional/Ensure/ClassPropagation/StubGrandparent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\ClassPropagation;
 

--- a/tests/Functional/Ensure/ClassPropagation/StubParent.php
+++ b/tests/Functional/Ensure/ClassPropagation/StubParent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\ClassPropagation;
 

--- a/tests/Functional/Ensure/ContractTest.php
+++ b/tests/Functional/Ensure/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure;
 

--- a/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\InterfacePropagation;
 

--- a/tests/Functional/Ensure/InterfacePropagation/Stub.php
+++ b/tests/Functional/Ensure/InterfacePropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\InterfacePropagation;
 

--- a/tests/Functional/Ensure/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Ensure/InterfacePropagation/StubInterfaceA.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\InterfacePropagation;
 

--- a/tests/Functional/Ensure/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Ensure/InterfacePropagation/StubInterfaceB.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure\InterfacePropagation;
 

--- a/tests/Functional/Ensure/Stub.php
+++ b/tests/Functional/Ensure/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Ensure;
 

--- a/tests/Functional/Invariant/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Invariant/ClassPropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\ClassPropagation;
 

--- a/tests/Functional/Invariant/ClassPropagation/Stub.php
+++ b/tests/Functional/Invariant/ClassPropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\ClassPropagation;
 

--- a/tests/Functional/Invariant/ContractTest.php
+++ b/tests/Functional/Invariant/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant;
 

--- a/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 

--- a/tests/Functional/Invariant/InterfacePropagation/Stub.php
+++ b/tests/Functional/Invariant/InterfacePropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 

--- a/tests/Functional/Invariant/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Invariant/InterfacePropagation/StubInterfaceA.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 

--- a/tests/Functional/Invariant/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Invariant/InterfacePropagation/StubInterfaceB.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant\InterfacePropagation;
 

--- a/tests/Functional/Invariant/Stub.php
+++ b/tests/Functional/Invariant/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Invariant;
 

--- a/tests/Functional/Verify/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/Stub.php
+++ b/tests/Functional/Verify/ClassPropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/StubGrandparent.php
+++ b/tests/Functional/Verify/ClassPropagation/StubGrandparent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/StubParent.php
+++ b/tests/Functional/Verify/ClassPropagation/StubParent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/StubParentWithInheritDoc.php
+++ b/tests/Functional/Verify/ClassPropagation/StubParentWithInheritDoc.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ClassPropagation/StubWithInheritDoc.php
+++ b/tests/Functional/Verify/ClassPropagation/StubWithInheritDoc.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\ClassPropagation;
 

--- a/tests/Functional/Verify/ContractTest.php
+++ b/tests/Functional/Verify/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify;
 

--- a/tests/Functional/Verify/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/InterfacePropagation/Stub.php
+++ b/tests/Functional/Verify/InterfacePropagation/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/InterfacePropagation/StubInterfaceA.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubInterfaceA.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/InterfacePropagation/StubInterfaceB.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubInterfaceB.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/InterfacePropagation/StubWithInheritDoc.php
+++ b/tests/Functional/Verify/InterfacePropagation/StubWithInheritDoc.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify\InterfacePropagation;
 

--- a/tests/Functional/Verify/Stub.php
+++ b/tests/Functional/Verify/Stub.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * PHP Deal framework
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+
+declare(strict_types=1);
 
 namespace PhpDeal\Functional\Verify;
 


### PR DESCRIPTION
# Changed log
- Fix PSR-12 coding style error. The error is as follows:
```
ERROR : The file-level docblock must follow the opening PHP tag in the file header
```