### PR TITLE
Improve PHPUnit fixture methods

### DIFF
--- a/tests/Functional/Ensure/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Ensure/ClassPropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Ensure/ContractTest.php
+++ b/tests/Functional/Ensure/ContractTest.php
@@ -23,13 +23,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Ensure/InterfacePropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Inherit/ContractTest.php
+++ b/tests/Functional/Inherit/ContractTest.php
@@ -11,13 +11,13 @@ class ContractTest extends TestCase
     /** @var StubWithInherit */
     private $stubWithInherit;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->stubWithoutInherit = new StubWithoutInherit();
         $this->stubWithInherit = new StubWithInherit();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stubWithoutInherit, $this->stubWithInherit);
     }

--- a/tests/Functional/Invariant/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Invariant/ClassPropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Invariant/ContractTest.php
+++ b/tests/Functional/Invariant/ContractTest.php
@@ -23,13 +23,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Invariant/InterfacePropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Verify/ClassPropagation/ContractTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/ClassPropagation/ContractWithInheritDocTest.php
@@ -27,13 +27,13 @@ class ContractWithInheritDocTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new StubWithInheritDoc();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Verify/ContractTest.php
+++ b/tests/Functional/Verify/ContractTest.php
@@ -23,13 +23,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Verify/InterfacePropagation/ContractTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractTest.php
@@ -26,13 +26,13 @@ class ContractTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new Stub();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();

--- a/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
+++ b/tests/Functional/Verify/InterfacePropagation/ContractWithInheritDocTest.php
@@ -27,13 +27,13 @@ class ContractWithInheritDocTest extends TestCase
      */
     private $stub;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stub = new StubWithInheritDoc();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->stub);
         parent::tearDown();


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture](https://phpunit.readthedocs.io/en/7.5/fixtures.html), the `setUp` and `tearDown` methods are `protected` with native `void` type hint.